### PR TITLE
Add gym planner website with weeks, planning, and nutrition modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Gym Planner
+
+A simple gym training planner with weeks, planning, and nutrition modules. Data is stored locally so your progress persists offline.
+
+## Run Locally
+
+1. Clone this repository.
+2. Open `index.html` in your browser.
+
+No build steps or dependencies are required.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,315 @@
+const defaultState = { weeks: [], presets: [], plan: [], nutrition: {} };
+let state = loadState();
+let currentWeek = 0;
+
+function loadState() {
+  try {
+    return JSON.parse(localStorage.getItem('gym-planner')) || defaultState;
+  } catch (e) {
+    return defaultState;
+  }
+}
+function saveState() {
+  localStorage.setItem('gym-planner', JSON.stringify(state));
+}
+
+// Navigation
+function initNav() {
+  const buttons = document.querySelectorAll('#bottom-nav button');
+  buttons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('.page').forEach(p => p.classList.remove('active'));
+      document.getElementById(btn.dataset.target).classList.add('active');
+      buttons.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+    });
+  });
+}
+
+// Weeks Module
+function renderWeeks() {
+  if (state.weeks.length === 0) {
+    state.weeks.push([]);
+  }
+  const tabs = document.getElementById('week-tabs');
+  tabs.innerHTML = '';
+  state.weeks.forEach((w, idx) => {
+    const li = document.createElement('li');
+    li.textContent = 'Week ' + (idx + 1);
+    li.dataset.index = idx;
+    if (idx === currentWeek) li.classList.add('active');
+    li.addEventListener('click', () => {
+      currentWeek = idx;
+      renderWeeks();
+    });
+    tabs.appendChild(li);
+  });
+  renderWeekContent();
+}
+
+function renderWeekContent() {
+  const container = document.getElementById('week-content');
+  container.innerHTML = '';
+  const week = state.weeks[currentWeek] || [];
+  week.forEach((block, idx) => {
+    const div = document.createElement('div');
+    div.className = 'workout';
+    div.draggable = true;
+    div.dataset.index = idx;
+    div.innerHTML = `
+      <i class="icon fas ${block.icon || 'fa-dumbbell'}"></i>
+      <input type="checkbox" data-id="${block.id}" ${block.completed ? 'checked' : ''}>
+      <div class="details">
+        <strong>${block.name}</strong> - ${block.sets}x${block.reps} ${block.weight ? '@'+block.weight+'kg' : ''}
+      </div>`;
+    container.appendChild(div);
+  });
+
+  container.querySelectorAll('input[type="checkbox"]').forEach(cb => {
+    cb.addEventListener('change', e => {
+      const id = Number(e.target.dataset.id);
+      const block = state.weeks[currentWeek].find(b => b.id === id);
+      if (block) block.completed = e.target.checked;
+      saveState();
+    });
+  });
+
+  enableDrag(container);
+}
+
+function enableDrag(container) {
+  let draggedIndex = null;
+  container.querySelectorAll('.workout').forEach(item => {
+    item.addEventListener('dragstart', e => {
+      draggedIndex = Number(e.target.dataset.index);
+      e.target.classList.add('dragging');
+    });
+    item.addEventListener('dragend', e => {
+      e.target.classList.remove('dragging');
+    });
+  });
+  container.addEventListener('dragover', e => e.preventDefault());
+  container.addEventListener('drop', e => {
+    e.preventDefault();
+    const target = e.target.closest('.workout');
+    if (!target) return;
+    const targetIndex = Number(target.dataset.index);
+    const week = state.weeks[currentWeek];
+    const [moved] = week.splice(draggedIndex, 1);
+    week.splice(targetIndex, 0, moved);
+    saveState();
+    renderWeekContent();
+  });
+}
+
+function addBlock() {
+  const names = state.presets.map(p => p.name).join(', ');
+  let choice = prompt('Enter exercise name or choose preset:\n' + names);
+  if (!choice) return;
+  let preset = state.presets.find(p => p.name === choice);
+  let block;
+  if (preset) {
+    block = { ...preset, id: Date.now(), presetId: preset.id, completed: false };
+  } else {
+    const sets = prompt('Sets?', '3');
+    const reps = prompt('Reps?', '10');
+    const weight = prompt('Weight (kg)?');
+    const icon = prompt('Font Awesome icon?', 'fa-dumbbell');
+    block = {
+      id: Date.now(),
+      name: choice,
+      sets: Number(sets),
+      reps: Number(reps),
+      weight: weight ? Number(weight) : null,
+      notes: '',
+      icon,
+      completed: false
+    };
+  }
+  state.weeks[currentWeek].push(block);
+  saveState();
+  renderWeekContent();
+}
+
+function addWeek() {
+  const week = state.plan.map(pid => {
+    const preset = state.presets.find(p => p.id === Number(pid));
+    return preset ? { ...preset, id: Date.now() + Math.random(), presetId: preset.id, completed: false } : null;
+  }).filter(Boolean);
+  state.weeks.push(week);
+  currentWeek = state.weeks.length - 1;
+  saveState();
+  renderWeeks();
+}
+
+document.getElementById('add-block').addEventListener('click', addBlock);
+document.getElementById('add-week').addEventListener('click', addWeek);
+
+// Planning Module
+const presetForm = document.getElementById('preset-form');
+presetForm.addEventListener('submit', e => {
+  e.preventDefault();
+  const preset = {
+    id: Date.now(),
+    name: document.getElementById('preset-name').value,
+    sets: Number(document.getElementById('preset-sets').value),
+    reps: Number(document.getElementById('preset-reps').value),
+    weight: document.getElementById('preset-weight').value ? Number(document.getElementById('preset-weight').value) : null,
+    notes: document.getElementById('preset-notes').value,
+    icon: document.getElementById('preset-icon').value
+  };
+  state.presets.push(preset);
+  presetForm.reset();
+  saveState();
+  renderPresets();
+  renderPlan();
+});
+
+function renderPresets() {
+  const list = document.getElementById('preset-list');
+  list.innerHTML = '';
+  state.presets.forEach(p => {
+    const li = document.createElement('li');
+    li.innerHTML = `<span><i class="fas ${p.icon}"></i> ${p.name} ${p.sets}x${p.reps}</span><button data-id="${p.id}"><i class="fas fa-trash"></i></button>`;
+    li.addEventListener('click', () => editPreset(p));
+    li.querySelector('button').addEventListener('click', e => {
+      e.stopPropagation();
+      removePreset(p.id);
+    });
+    list.appendChild(li);
+  });
+  const select = document.getElementById('plan-select');
+  select.innerHTML = '';
+  state.presets.forEach(p => {
+    const opt = document.createElement('option');
+    opt.value = p.id;
+    opt.textContent = p.name;
+    select.appendChild(opt);
+  });
+}
+
+function editPreset(p) {
+  const name = prompt('Name', p.name);
+  if (!name) return;
+  const sets = prompt('Sets', p.sets);
+  const reps = prompt('Reps', p.reps);
+  const weight = prompt('Weight', p.weight || '');
+  const notes = prompt('Notes', p.notes || '');
+  const icon = prompt('Icon', p.icon);
+  Object.assign(p, { name, sets: Number(sets), reps: Number(reps), weight: weight ? Number(weight) : null, notes, icon });
+  cascadePreset(p);
+  saveState();
+  renderPresets();
+  renderPlan();
+  renderWeekContent();
+}
+
+function removePreset(id) {
+  state.presets = state.presets.filter(p => p.id !== id);
+  state.plan = state.plan.filter(pid => pid !== id);
+  state.weeks.forEach(week => {
+    for (let i = week.length - 1; i >= 0; i--) {
+      if (week[i].presetId === id) week.splice(i, 1);
+    }
+  });
+  saveState();
+  renderPresets();
+  renderPlan();
+  renderWeekContent();
+}
+
+function cascadePreset(preset) {
+  state.weeks.forEach(week => {
+    week.forEach(block => {
+      if (block.presetId === preset.id && !block.completed) {
+        Object.assign(block, { ...preset });
+      }
+    });
+  });
+}
+
+function renderPlan() {
+  const list = document.getElementById('plan-list');
+  list.innerHTML = '';
+  state.plan.forEach((pid, idx) => {
+    const preset = state.presets.find(p => p.id === Number(pid));
+    if (!preset) return;
+    const li = document.createElement('li');
+    li.innerHTML = `<span>${preset.name}</span><button data-idx="${idx}"><i class="fas fa-trash"></i></button>`;
+    li.querySelector('button').addEventListener('click', () => {
+      state.plan.splice(idx, 1);
+      saveState();
+      renderPlan();
+    });
+    list.appendChild(li);
+  });
+}
+
+document.getElementById('add-plan-item').addEventListener('click', () => {
+  const sel = document.getElementById('plan-select');
+  if (sel.value) {
+    state.plan.push(Number(sel.value));
+    saveState();
+    renderPlan();
+  }
+});
+
+// Nutrition Module
+function initNutrition() {
+  const dateInput = document.getElementById('nutri-date');
+  const today = new Date().toISOString().split('T')[0];
+  dateInput.value = today;
+  dateInput.addEventListener('change', () => renderNutrition(dateInput.value));
+
+  const foodForm = document.getElementById('food-form');
+  foodForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const date = dateInput.value;
+    const entry = {
+      name: document.getElementById('food-name').value,
+      calories: Number(document.getElementById('food-calories').value),
+      protein: Number(document.getElementById('food-protein').value),
+      carbs: Number(document.getElementById('food-carbs').value),
+      fat: Number(document.getElementById('food-fat').value)
+    };
+    if (!state.nutrition[date]) state.nutrition[date] = [];
+    state.nutrition[date].push(entry);
+    foodForm.reset();
+    saveState();
+    renderNutrition(date);
+  });
+  renderNutrition(today);
+}
+
+function renderNutrition(date) {
+  const list = document.getElementById('food-list');
+  const totals = { calories: 0, protein: 0, carbs: 0, fat: 0 };
+  list.innerHTML = '';
+  const entries = state.nutrition[date] || [];
+  entries.forEach((item, idx) => {
+    totals.calories += item.calories;
+    totals.protein += item.protein;
+    totals.carbs += item.carbs;
+    totals.fat += item.fat;
+    const li = document.createElement('li');
+    li.innerHTML = `<span>${item.name} - ${item.calories} kcal P${item.protein} C${item.carbs} F${item.fat}</span><button data-idx="${idx}"><i class="fas fa-trash"></i></button>`;
+    li.querySelector('button').addEventListener('click', () => {
+      entries.splice(idx, 1);
+      saveState();
+      renderNutrition(date);
+    });
+    list.appendChild(li);
+  });
+  document.getElementById('macro-totals').textContent = `Total: ${totals.calories} kcal | P ${totals.protein}g C ${totals.carbs}g F ${totals.fat}g`;
+}
+
+// Initialize
+function init() {
+  initNav();
+  renderWeeks();
+  renderPresets();
+  renderPlan();
+  initNutrition();
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gym Planner</title>
+  <link rel="stylesheet" href="style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-Lr4Xu2f+5XxhxL7sRKqGZo4PMBVXrS5aXoaZySUdkGFUTkOcJCIZy9FHn5Vf3L7hIwrKyYVJZZzKzb0LC+2+Kw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+</head>
+<body>
+  <header id="landing">
+    <h1>Gym Planner</h1>
+    <p>Plan your training and meals</p>
+    <a href="#app" class="start-btn"><i class="fas fa-arrow-down"></i></a>
+  </header>
+
+  <main id="app">
+    <section id="weeks" class="page active" aria-label="Weeks">
+      <div id="week-nav">
+        <ul id="week-tabs" role="tablist"></ul>
+        <button id="add-week" aria-label="Add week"><i class="fas fa-plus"></i></button>
+      </div>
+      <div id="week-content"></div>
+      <button id="add-block" class="fab" aria-label="Add workout"><i class="fas fa-plus"></i></button>
+    </section>
+
+    <section id="planning" class="page" aria-label="Planning">
+      <h2>Presets</h2>
+      <ul id="preset-list"></ul>
+      <form id="preset-form">
+        <input type="text" id="preset-name" placeholder="Name" required>
+        <input type="number" id="preset-sets" placeholder="Sets" required>
+        <input type="number" id="preset-reps" placeholder="Reps" required>
+        <input type="number" id="preset-weight" placeholder="Weight (kg)">
+        <textarea id="preset-notes" placeholder="Notes"></textarea>
+        <select id="preset-icon">
+          <option value="fa-dumbbell">Dumbbell</option>
+          <option value="fa-person-arrow-up-from-line">Pull Ups</option>
+          <option value="fa-hand-back-fist">Biceps</option>
+          <option value="fa-person-running">Legs</option>
+        </select>
+        <button type="submit">Save Preset</button>
+      </form>
+
+      <h2>Weekly Plan</h2>
+      <div id="plan-builder">
+        <select id="plan-select"></select>
+        <button id="add-plan-item">Add to Plan</button>
+        <ul id="plan-list"></ul>
+      </div>
+    </section>
+
+    <section id="nutrition" class="page" aria-label="Nutrition">
+      <h2>Nutrition</h2>
+      <input type="date" id="nutri-date">
+      <form id="food-form">
+        <input type="text" id="food-name" placeholder="Food" required>
+        <input type="number" id="food-calories" placeholder="Calories" required>
+        <input type="number" id="food-protein" placeholder="Protein (g)" required>
+        <input type="number" id="food-carbs" placeholder="Carbs (g)" required>
+        <input type="number" id="food-fat" placeholder="Fat (g)" required>
+        <button type="submit">Add</button>
+      </form>
+      <ul id="food-list"></ul>
+      <div id="macro-totals"></div>
+    </section>
+  </main>
+
+  <nav id="bottom-nav">
+    <button data-target="weeks" class="active" aria-label="Weeks"><i class="fas fa-calendar-week"></i><span>Weeks</span></button>
+    <button data-target="planning" aria-label="Planning"><i class="fas fa-list"></i><span>Planning</span></button>
+    <button data-target="nutrition" aria-label="Nutrition"><i class="fas fa-apple-whole"></i><span>Nutrition</span></button>
+  </nav>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,167 @@
+:root {
+  --gold: #FFD700;
+  --black: #000000;
+}
+
+body {
+  margin: 0;
+  font-family: 'Poppins', sans-serif;
+  background: var(--black);
+  color: #fff;
+  scroll-behavior: smooth;
+}
+
+#landing {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  background: var(--black);
+  color: var(--gold);
+}
+#landing .start-btn {
+  margin-top: 20px;
+  font-size: 2rem;
+  color: var(--gold);
+}
+
+#app {
+  min-height: 100vh;
+  padding-bottom: 60px;
+}
+
+.page {
+  display: none;
+  padding: 1rem;
+  animation: fade 0.3s ease;
+}
+.page.active {
+  display: block;
+}
+@keyframes fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+#week-nav {
+  display: flex;
+  align-items: center;
+  overflow-x: auto;
+  background: #111;
+}
+#week-tabs {
+  display: flex;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+#week-tabs li {
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+}
+#week-tabs li.active {
+  border-bottom-color: var(--gold);
+  color: var(--gold);
+}
+#week-nav button {
+  background: none;
+  border: none;
+  color: var(--gold);
+  font-size: 1.5rem;
+}
+
+.workout {
+  background: #111;
+  margin: 0.5rem 0;
+  padding: 0.5rem;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  transition: transform 0.3s;
+}
+.workout.dragging {
+  opacity: 0.5;
+}
+.workout i.icon {
+  margin-right: 0.5rem;
+  font-size: 2rem;
+  color: var(--gold);
+}
+.workout .details {
+  flex: 1;
+}
+.workout input[type="checkbox"] {
+  margin-right: 0.5rem;
+}
+
+.fab {
+  position: fixed;
+  right: 1rem;
+  bottom: 80px;
+  background: var(--gold);
+  color: var(--black);
+  border: none;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  font-size: 1.5rem;
+}
+
+#bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  display: flex;
+  justify-content: space-around;
+  background: #111;
+  border-top: 1px solid #333;
+}
+#bottom-nav button {
+  flex: 1;
+  background: none;
+  border: none;
+  color: #fff;
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  transition: color 0.3s;
+}
+#bottom-nav button.active,
+#bottom-nav button:hover {
+  color: var(--gold);
+}
+
+#preset-form,
+#food-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+#preset-list,
+#plan-list,
+#food-list {
+  list-style: none;
+  padding: 0;
+}
+#preset-list li,
+#plan-list li,
+#food-list li {
+  background: #111;
+  margin: 0.5rem 0;
+  padding: 0.5rem;
+  border-radius: 6px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+#macro-totals {
+  margin-top: 1rem;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- add gold-and-black themed landing page and navigation
- implement weeks, planning, and nutrition modules with localStorage persistence
- include drag-and-drop workouts, presets, and macro tracker

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cea8d0290832d9ec56ed219eb3102